### PR TITLE
Make babel transpile to ES5

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', {
-      // shippedProposals: true,
-      // useBuiltIns: 'usage',
-      targets: {
-        node: 'current',
-      },
-    }],
+    '@babel/preset-env',
     '@babel/preset-react',
   ],
   plugins: [


### PR DESCRIPTION
Removes the "node: current" option from babel config, since storybook doesn't run in node but in the browser. 

As per [Storybook documentation](https://storybook.js.org/addons/writing-addons/#package-maintenance) the packaged add-on must be transpiled to ES5. The @babel/preset-env will do this if left unconfigured. 

Fixes #1 